### PR TITLE
Improve/avoid pagebreak

### DIFF
--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -478,9 +478,9 @@ def main():
     lines.append("        </ram:DueDateDateTime>\n")
     lines.append("      </ram:SpecifiedTradePaymentTerms>\n")
     lines.append("    </ram:ApplicableHeaderTradeSettlement>\n")
-    lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
     print(articles)
     for article in articles:
+        lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
         lines.append("        <ram:LineID>" + str(articles.index(article) + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
@@ -508,8 +508,10 @@ def main():
         lines.append("          <ram:LineTotalAmount>" + str(float(article[1]) * float(article[2])) + "</ram:LineTotalAmount>\n")
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
+        lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
     print(discounts)
     for discount in discounts:
+        lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
         lines.append("        <ram:LineID>" + str(discounts.index(discount) + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
@@ -534,7 +536,7 @@ def main():
         lines.append("          <ram:LineTotalAmount>-" + str(discount[1]) + "</ram:LineTotalAmount>\n")
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
-    lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
+        lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
     lines.append("  </rsm:SupplyChainTradeTransaction>\n")
     lines.append("</rsm:CrossIndustryInvoice>\n")
     

--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -205,10 +205,10 @@ def main():
         description = ""
         if article[3] != "":
             description = f'<br>{article[3]}'
-        table_html += f'<tr><td class="invoice-item-name"><strong>{article[0]}</strong>{description}</td><td>{convert_to_euro_string(template_lines, article[1])}</td><td>{article[2]}</td><td>{convert_to_euro_string(template_lines, float(article[1]) * float(article[2]))}</td></tr>\n'
+        table_html += f'<tr style="page-break-inside:avoid;"><td class="invoice-item-name"><strong>{article[0]}</strong>{description}</td><td>{convert_to_euro_string(template_lines, article[1])}</td><td>{article[2]}</td><td>{convert_to_euro_string(template_lines, float(article[1]) * float(article[2]))}</td></tr>\n'
 
     for discount in discounts:
-        table_html += f'<tr><td class="invoice-item-name">{discount[0]}</td><td> - </td><td> - </td><td>- {convert_to_euro_string(template_lines, discount[1])}</td></tr>\n'
+        table_html += f'<tr style="page-break-inside:avoid;"><td class="invoice-item-name">{discount[0]}</td><td> - </td><td> - </td><td>- {convert_to_euro_string(template_lines, discount[1])}</td></tr>\n'
     
     # Calculate sum
     sum_netto = 0

--- a/src/html/invoice.html
+++ b/src/html/invoice.html
@@ -125,11 +125,12 @@ td {
           #!ITEMS
         </tbody>
         <tfoot>
-          <tr>
-            <td colspan="2">Gesamtbetrag (Netto)</td>
-            <td colspan="2">#!SUM-WITHOUT-VAT</td>
-          </tr>
-          <tr>
+          <div style="page-break-inside:avoid;"></div>
+            <tr>
+              <td colspan="2">Gesamtbetrag (Netto)</td>
+              <td colspan="2">#!SUM-WITHOUT-VAT</td>
+            </tr>
+            <tr>
               <td colspan="2">zzgl. Umsatzsteuer</td>
               <td>#!VAT-PERCENT</td>
               <td>#!VAT-ADDITION</td>
@@ -138,17 +139,20 @@ td {
               <td colspan="2">Gesamtbetrag (Brutto)</td>
               <td colspan="2">#!SUM-WITH-VAT</td>
             </tr>
+          </div>
         </tfoot>
     </table>
 
-    <p>
+    <div style="page-break-inside:avoid;">
+      <p>
         <!-- Das Leistungsdatum entspricht dem Rechnungsdatum. Der angegebene Preis ist ein Endpreis. Gemäß 19 § UStG erhebe ich keine Umsatzsteuer und weise diese folglich auch nicht aus. -->
         #!HINT
-    </p>
+      </p>
 
-    #!CLOSING <br>
-    <br>
-    #!SEN-NAME
+      #!CLOSING <br>
+      <br>
+      #!SEN-NAME
+    </div>
 </div>
 
 

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.19.0"
   fake_async:
     dependency: transitive
     description:
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.7"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.8"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   screen_retriever:
     dependency: transitive
     description:
@@ -119,7 +143,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -132,26 +156,26 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -164,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -176,14 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.3.0"
   window_manager:
     dependency: "direct dev"
     description:
@@ -193,5 +217,5 @@ packages:
     source: hosted
     version: "0.3.4"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Observation:
If an invoice is longer than one page, the page break occurs when the page is full. It would be more readable if the break occured
- not within invoice articles or the discount
- not within the table footer
- not within the last HINT and the Name

Solution:
Added a few `style="page-break-inside:avoid;"` attributes to advice the pdf creator not to break these sections.

Known limitation:
If an invoice continues on the next page, the table footer is printed on the bottom of the first page an the bottom of the table. This has nothing to do with the changes in this PR, but in my opinion it's at least misleading if the first page shows the footer with the total sums an not with the subtotals. The reason for repeating the footer is the use of the `tfoot` tag.  I'll suggest a PR to change this (I thought is is batter to separate these different concerns into different PRs). 