### PR TITLE
Improve/refactor html template

### DIFF
--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -478,9 +478,9 @@ def main():
     lines.append("        </ram:DueDateDateTime>\n")
     lines.append("      </ram:SpecifiedTradePaymentTerms>\n")
     lines.append("    </ram:ApplicableHeaderTradeSettlement>\n")
-    lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
     print(articles)
     for article in articles:
+        lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
         lines.append("        <ram:LineID>" + str(articles.index(article) + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
@@ -508,8 +508,10 @@ def main():
         lines.append("          <ram:LineTotalAmount>" + str(float(article[1]) * float(article[2])) + "</ram:LineTotalAmount>\n")
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
+        lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
     print(discounts)
     for discount in discounts:
+        lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
         lines.append("        <ram:LineID>" + str(discounts.index(discount) + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
@@ -534,7 +536,7 @@ def main():
         lines.append("          <ram:LineTotalAmount>-" + str(discount[1]) + "</ram:LineTotalAmount>\n")
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
-    lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
+        lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
     lines.append("  </rsm:SupplyChainTradeTransaction>\n")
     lines.append("</rsm:CrossIndustryInvoice>\n")
     

--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -228,69 +228,105 @@ def main():
     sen_info_description = ""
     sen_info_data = ""
     if is_key_present(template_lines, "SEN-COMPANY"):
-        sen_info_description += "<br>"
-        sen_company = get_value(template_lines, "SEN-COMPANY")
-        sen_info_data += f"<strong>{sen_company}</strong> <br>"
-
+        sen_company = get_value(template_lines, "SEN-COMPANY").strip()
+        sen_info_description +=  """  <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;"></td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;"><strong>{sen_company}</strong></td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "SEN-NAME") and is_key_present(template_lines, "SEN-STREET") and is_key_present(template_lines, "SEN-CITY"):
-        sen_info_description += "Anschrift <br> <br> <br> <br>"
-        sen_name = get_value(template_lines, "SEN-NAME")
-        sen_name = get_value(template_lines, "SEN-NAME")
-        sen_street = get_value(template_lines, "SEN-STREET")
-        sen_zip = get_value(template_lines, "SEN-ZIP")
-        sen_city = get_value(template_lines, "SEN-CITY")
-        sen_info_data += f"{sen_name} <br> {sen_street} <br> {sen_zip} {sen_city} <br> <br>"
+        sen_name = get_value(template_lines, "SEN-NAME").strip()
+        sen_street = get_value(template_lines, "SEN-STREET").strip()
+        sen_zip = get_value(template_lines, "SEN-ZIP").strip()
+        sen_city = get_value(template_lines, "SEN-CITY").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">Anschrift</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;">{sen_name}<br>{sen_street}<br>{sen_zip} {sen_city}</td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "SEN-EMAIL"):
-        sen_info_description += "E-Mail <br>"
-        sen_email = get_value(template_lines, "SEN-EMAIL")
-        sen_info_data += f"<a style=\"color: grey; text-decoration: none;\" href=\"mailto:{sen_email}\">{sen_email}</a> <br>"
+        sen_email = get_value(template_lines, "SEN-EMAIL").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">E-Mail</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;"><a style=\"color: grey; text-decoration: none;\" href=\"mailto:{sen_email}\">{sen_email}</a></td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "SEN-PHONE"):
-        sen_info_description += "Telefon <br>"
-        sen_phone = get_value(template_lines, "SEN-PHONE")
-        sen_info_data += f"<a style=\"color: grey; text-decoration: none;\" href=\"tel:{sen_phone}\">{sen_phone}</a> <br>"
+        sen_phone = get_value(template_lines, "SEN-PHONE").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">Telefon</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;"><a style=\"color: grey; text-decoration: none;\" href=\"tel:{sen_phone}\">{sen_phone}</a></td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "SEN-WEBSITE"):
-        sen_info_description += "Website <br>"
-        sen_website = get_value(template_lines, "SEN-WEBSITE")
-        sen_info_data += f"<a style=\"color: grey; text-decoration: none;\" href=\"https://{sen_website}\">{sen_website}</a> <br>"
-    sen_info_description += "<br>"
-    sen_info_data += "<br>"
+        sen_website = get_value(template_lines, "SEN-WEBSITE").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">Website</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;"><a style=\"color: grey; text-decoration: none;\" href=\"https://{sen_website}\">{sen_website}</a></td> \n"""
+        sen_info_description +=  """      </tr> \n"""
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">&nbsp;</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">&nbsp;</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "SEN-TAX-ID"):
-        sen_info_description += "Ust-IdNr. <br>"
-        sen_tax_id = get_value(template_lines, "SEN-TAX-ID")
-        sen_info_data += f"{sen_tax_id} <br>"
-    sen_info_description += "<br>"
-    sen_info_data += "<br>"
+        sen_tax_id = get_value(template_lines, "SEN-TAX-ID").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">Ust-IdNr.</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;">{sen_tax_id}</td> \n"""
+        sen_info_description +=  """      </tr> \n"""
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">&nbsp;</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">&nbsp;</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
+
     if is_key_present(template_lines, "MONEY-INSTITUTE"):
-        sen_info_description += "Institut <br>"
-        sen_money_institute = get_value(template_lines, "MONEY-INSTITUTE")
-        sen_info_data += f"{sen_money_institute} <br>"
+        sen_money_institute = get_value(template_lines, "MONEY-INSTITUTE").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">Institut</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;">{sen_money_institute}</td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "IBAN"):
-        sen_info_description += "IBAN <br>"
-        sen_iban = get_value(template_lines, "IBAN")
-        sen_info_data += f"{sen_iban} <br>"
+        sen_iban = get_value(template_lines, "IBAN").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">IBAN</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;">{sen_iban}</td> \n"""
+        sen_info_description +=  """      </tr> \n"""
     if is_key_present(template_lines, "BIC"):
-        sen_info_description += "BIC <br>"
-        sen_bic = get_value(template_lines, "BIC")
-        sen_info_data += f"{sen_bic} <br>"
-    
-    sen_info_description += "<br>"
-    sen_info_data += "<br>"
+        sen_bic = get_value(template_lines, "BIC").strip()
+        sen_info_description +=  """      <tr> \n"""
+        sen_info_description +=  """        <td style="text-align: right;">BIC</td> \n"""
+        sen_info_description += f"""        <td style="text-align: left;">{sen_bic}</td> \n"""
+        sen_info_description +=  """      </tr> \n"""
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">&nbsp;</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">&nbsp;</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
 
     # Add invoiceDate to the table in sen_info section
-    sen_info_description += "Rechnungsdatum <br>"
-    sen_info_data += f"{date} <br>"
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">Rechnungsdatum</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">{date}</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
 
     # Add invoiceNumber to the table in sen_info section
-    sen_info_description += "Rechnungsnummer <br>"
-    sen_info_data += f"{invoice_number} <br>"
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">Rechnungsnummer</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">{invoice_number}</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
 
     # Add serviceDate (Leistungsdatum) to the table in sen_info section
     if args.serviceDate == "today":
         args.serviceDate = date
-    sen_info_description += "Leistungsdatum <br>"
-    sen_info_data += f"{args.serviceDate} <br>"
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">Leistungsdatum</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">{args.serviceDate}</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
 
-    
+    # Add two rows as space after the table
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">&nbsp;</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">&nbsp;</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
+    sen_info_description +=  """      <tr> \n"""
+    sen_info_description +=  """        <td style="text-align: right;">&nbsp;</td> \n"""
+    sen_info_description += f"""        <td style="text-align: left;">&nbsp;</td> \n"""
+    sen_info_description +=  """      </tr> \n"""
 
     # Replace all keys with the values (GENERATE THE HTML FILE)
     for i in range(len(lines)):
@@ -479,10 +515,11 @@ def main():
     lines.append("      </ram:SpecifiedTradePaymentTerms>\n")
     lines.append("    </ram:ApplicableHeaderTradeSettlement>\n")
     print(articles)
+    i=0
     for article in articles:
         lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
-        lines.append("        <ram:LineID>" + str(articles.index(article) + 1) + "</ram:LineID>\n")
+        lines.append("        <ram:LineID>" + str(i + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
         lines.append("      <ram:SpecifiedTradeProduct>\n")
         lines.append("        <ram:Name>" + str(article[0]) + "</ram:Name>\n")
@@ -509,11 +546,13 @@ def main():
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
         lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
+        i=i+1
     print(discounts)
+    i=0
     for discount in discounts:
         lines.append("    <ram:IncludedSupplyChainTradeLineItem>\n")
         lines.append("      <ram:AssociatedDocumentLineDocument>\n")
-        lines.append("        <ram:LineID>" + str(discounts.index(discount) + 1) + "</ram:LineID>\n")
+        lines.append("        <ram:LineID>" + str(i + 1) + "</ram:LineID>\n")
         lines.append("      </ram:AssociatedDocumentLineDocument>\n")
         lines.append("      <ram:SpecifiedTradeProduct>\n")
         lines.append("        <ram:Name>" + str(discount[0]) + "</ram:Name>\n")
@@ -537,6 +576,7 @@ def main():
         lines.append("        </ram:SpecifiedTradeSettlementLineMonetarySummation>\n")
         lines.append("      </ram:SpecifiedLineTradeSettlement>\n")
         lines.append("    </ram:IncludedSupplyChainTradeLineItem>\n")
+        i=i+1
     lines.append("  </rsm:SupplyChainTradeTransaction>\n")
     lines.append("</rsm:CrossIndustryInvoice>\n")
     
@@ -560,4 +600,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -205,10 +205,10 @@ def main():
         description = ""
         if article[3] != "":
             description = f'<br>{article[3]}'
-        table_html += f'<tr><td class="invoice-item-name"><strong>{article[0]}</strong>{description}</td><td>{convert_to_euro_string(template_lines, article[1])}</td><td>{article[2]}</td><td>{convert_to_euro_string(template_lines, float(article[1]) * float(article[2]))}</td></tr>\n'
+        table_html += f'<tr style="page-break-inside:avoid;"><td class="invoice-item-name"><strong>{article[0]}</strong>{description}</td><td>{convert_to_euro_string(template_lines, article[1])}</td><td>{article[2]}</td><td>{convert_to_euro_string(template_lines, float(article[1]) * float(article[2]))}</td></tr>\n'
 
     for discount in discounts:
-        table_html += f'<tr><td class="invoice-item-name">{discount[0]}</td><td> - </td><td> - </td><td>- {convert_to_euro_string(template_lines, discount[1])}</td></tr>\n'
+        table_html += f'<tr style="page-break-inside:avoid;"><td class="invoice-item-name">{discount[0]}</td><td> - </td><td> - </td><td>- {convert_to_euro_string(template_lines, discount[1])}</td></tr>\n'
     
     # Calculate sum
     sum_netto = 0

--- a/src/html/invoice.html
+++ b/src/html/invoice.html
@@ -125,11 +125,12 @@ td {
           #!ITEMS
         </tbody>
         <tfoot>
-          <tr>
-            <td colspan="2">Gesamtbetrag (Netto)</td>
-            <td colspan="2">#!SUM-WITHOUT-VAT</td>
-          </tr>
-          <tr>
+          <div style="page-break-inside:avoid;"></div>
+            <tr>
+              <td colspan="2">Gesamtbetrag (Netto)</td>
+              <td colspan="2">#!SUM-WITHOUT-VAT</td>
+            </tr>
+            <tr>
               <td colspan="2">zzgl. Umsatzsteuer</td>
               <td>#!VAT-PERCENT</td>
               <td>#!VAT-ADDITION</td>
@@ -138,17 +139,20 @@ td {
               <td colspan="2">Gesamtbetrag (Brutto)</td>
               <td colspan="2">#!SUM-WITH-VAT</td>
             </tr>
+          </div>
         </tfoot>
     </table>
 
-    <p>
+    <div style="page-break-inside:avoid;">
+      <p>
         <!-- Das Leistungsdatum entspricht dem Rechnungsdatum. Der angegebene Preis ist ein Endpreis. Gemäß 19 § UStG erhebe ich keine Umsatzsteuer und weise diese folglich auch nicht aus. -->
         #!HINT
-    </p>
+      </p>
 
-    #!CLOSING <br>
-    <br>
-    #!SEN-NAME
+      #!CLOSING <br>
+      <br>
+      #!SEN-NAME
+    </div>
 </div>
 
 

--- a/src/html/invoice.html
+++ b/src/html/invoice.html
@@ -1,156 +1,140 @@
 <style>
-@media print {
-  @page { margin: 2cm 0cm 2cm 0cm;
-    size:210mm 297mm;
+  @media print {
+      @page:first { margin: 1cm 1cm 2.5cm 2cm;
+      size:210mm 297mm;
+    }
+
+    @page { margin: 2.5cm 1cm 2.5cm 2cm;
+      size:210mm 297mm;
+    }
   }
-}
 
-body {
+  body {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 13px;
+    font-size: 12px;
     line-height: 1.5;
-}
-
-.container {
-  width: 100%;
-}
-
-.column {
-  width: 33.33%;
-  float: left;
-}
-
-.invoice-table {
-  width: 100%;
-  border-collapse: collapse;
-  text-align: right;
-  font-size: 13px;
-}
-
-thead {
-  border-bottom: 1px solid black;
-}
-
-tfoot {
-  border-top: 1px solid black;
-}
-
-td {
+  }
+  
+  .container {
+    width: 100%;
+  }
+  
+  .column {
+    width: 33.33%;
+    float: left;
+  }
+  
+  .invoice-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: right;
+    font-size: 13px;
+  }
+  
+  thead {
+    border-bottom: 1px solid black;
+  }
+  
+  tfoot {
+    border-top: 1px solid black;
+  }
+  
+  td {
     padding: 2px;
     vertical-align: top;
-}
-
-.invoice-item-name {
+  }
+  
+  .invoice-item-name {
     text-align: left;
-}
-
+  }
+  
 </style>
 
-<div style="padding:0cm 2cm 2cm 2cm;">
-   
-    <div class="container">
-        <div style="width: 50%; float: left;">
-            <img src="logo.png" style="height: 96px;">
-            <div style="height: 90px;"></div>
 
+<div class="container">
+  <div style="width: 50%; float: left;">
+    <img src="logo.png" style="height: 25mm;">
+    <div style="height: 10mm;"></div>
 
-            <div style="width: max-content; font-size: 10px;">
-                #!SEN-NAME - #!SEN-STREET, #!SEN-ZIP #!SEN-CITY
-                <div style="margin-top: 2px; background-color: black; height: 1px;"></div>
-            </div>
-
-            <div style="height: 10px;"></div>
-
-            <div>
-                #!REC-COMPANY <br>
-                #!REC-NAME <br>
-                #!REC-STREET <br>
-                #!REC-ZIP #!REC-CITY <br>
-            </div>
-
-        </div>
-        <div style="width: 18%; float: left; color: grey; text-align: right;">
-            <div style="height: 70px;"></div>
-            #!SEN-INFO-DESCRIPTION
-        </div>
-        <div style="width: 2%; float: left;">
-            <div style="height: 1px;"></div>
-        </div>
-        <div style="width: 30%; float: left; color: grey;">
-            <div style="height: 70px;"></div>
-            #!SEN-INFO-DATA
-        </div>
-       
+    <div style="width: max-content; font-size: 10px;">
+      #!SEN-NAME - #!SEN-STREET, #!SEN-ZIP #!SEN-CITY
+      <div style="margin-top: 2px; background-color: black; height: 1px;"></div>
     </div>
 
-    <div style="height: 330px;"></div>
+    <div style="height: 10px;"></div>
 
-    <!-- <div style="height: 100px;"></div>
-    <div style="text-align: right; font-weight: 600;">
-        #!SEN-CITY, den #!DATE<br>
-    </div> -->
-    <br>
-    <br>
-    <br>
-    <br>
-    <br>
-
-    <h3>Rechnung</h1>
-
-    <p>
-        #!SALUTATION
-    </p>
-
-    <p>
-        <!-- Bitte zahlen Sie den unten aufgeführten Gesamtbetrag unter Angabe der Rechnungsnummer (01.01.1970) bis zum 29.08.2023 auf das angegebene Konto ein. Vielen Dank für Ihr Vertrauen. -->
-        #!MESSAGE
-    </p>
-
-    <table class="invoice-table">
-        <thead>
-          <tr>
-            <th style="width: 60%; text-align: left;">Bezeichnung</th>
-            <th>Preis/Einheit</th>
-            <th>Menge</th>
-            <th>Betrag</th>
-          </tr>
-        </thead>
-        <tbody>
-          <!-- <tr>
-            <td class="invoice-item-name"><strong>Product 1</strong><br>Description</td>
-            <td>$10.00</td>
-            <td>1</td>
-            <td>$10.00</td>
-          </tr> -->
-          #!ITEMS
-          <div style="page-break-inside:avoid;"></div>
-            <tr style="border-top: 1px solid;">
-              <td colspan="2">Gesamtbetrag (Netto)</td>
-              <td colspan="2">#!SUM-WITHOUT-VAT</td>
-            </tr>
-            <tr>
-              <td colspan="2">zzgl. Umsatzsteuer</td>
-              <td>#!VAT-PERCENT</td>
-              <td>#!VAT-ADDITION</td>
-            </tr>
-            <tr style="font-weight: 600;">
-              <td colspan="2">Gesamtbetrag (Brutto)</td>
-              <td colspan="2">#!SUM-WITH-VAT</td>
-            </tr>
-          </div>
-        </tbody>
-    </table>
-
-    <div style="page-break-inside:avoid;">
-      <p>
-        <!-- Das Leistungsdatum entspricht dem Rechnungsdatum. Der angegebene Preis ist ein Endpreis. Gemäß 19 § UStG erhebe ich keine Umsatzsteuer und weise diese folglich auch nicht aus. -->
-        #!HINT
-      </p>
-
-      #!CLOSING <br>
-      <br>
-      #!SEN-NAME
+    <div style="font-size: 13px;">
+      #!REC-COMPANY <br>
+      #!REC-NAME <br>
+      #!REC-STREET <br>
+      #!REC-ZIP #!REC-CITY <br>
     </div>
+  </div>
+
+  <table style="width: 50%; float: left; color: grey; border-spacing: 2.5mm 0; padding: 13mm 0mm 0mm 0mm; font-size: 13px;">
+    #!SEN-INFO-DESCRIPTION
+  </table>
 </div>
 
+<!--
+<div style="text-align: right; font-weight: 600;">
+  Eggenfelden, den 05.01.2025<br>
+</div>
+-->
 
+<h3>Rechnung</h1>
+
+<p>
+  #!SALUTATION
+</p>
+
+<p>
+  <!-- Bitte zahlen Sie den unten aufgeführten Gesamtbetrag unter Angabe der Rechnungsnummer (01.01.1970) bis zum 29.08.2023 auf das angegebene Konto ein. Vielen Dank für Ihr Vertrauen. -->
+  #!MESSAGE
+</p>
+
+<table class="invoice-table">
+  <thead>
+    <tr>
+      <th style="width: 60%; text-align: left;">Bezeichnung</th>
+      <th>Preis/Einheit</th>
+      <th>Menge</th>
+      <th>Betrag</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- <tr>
+      <td class="invoice-item-name"><strong>Product 1</strong><br>Description</td>
+      <td>$10.00</td>
+      <td>1</td>
+      <td>$10.00</td>
+    </tr> -->
+    #!ITEMS
+    <div style="page-break-inside:avoid;">
+      <tr style="border-top: 1px solid;">
+        <td colspan="2">Gesamtbetrag (Netto)</td>
+        <td colspan="2">#!SUM-WITHOUT-VAT</td>
+      </tr>
+      <tr>
+        <td colspan="2">zzgl. Umsatzsteuer</td>
+        <td>#!VAT-PERCENT</td>
+        <td>#!VAT-ADDITION</td>
+      </tr>
+      <tr style="font-weight: 600;">
+        <td colspan="2">Gesamtbetrag (Brutto)</td>
+        <td colspan="2">#!SUM-WITH-VAT</td>
+      </tr>
+    </div>
+  </tbody>
+</table>
+
+<div style="page-break-inside:avoid;">
+  <p>
+    <!-- Das Leistungsdatum entspricht dem Rechnungsdatum. Der angegebene Preis ist ein Endpreis. Gemäß 19 § UStG erhebe ich keine Umsatzsteuer und weise diese folglich auch nicht aus. -->
+    #!HINT
+  </p>
+
+  <br>
+  #!CLOSING <br>
+  #!SEN-NAME
+</div>

--- a/src/html/invoice.html
+++ b/src/html/invoice.html
@@ -123,10 +123,8 @@ td {
             <td>$10.00</td>
           </tr> -->
           #!ITEMS
-        </tbody>
-        <tfoot>
           <div style="page-break-inside:avoid;"></div>
-            <tr>
+            <tr style="border-top: 1px solid;">
               <td colspan="2">Gesamtbetrag (Netto)</td>
               <td colspan="2">#!SUM-WITHOUT-VAT</td>
             </tr>
@@ -140,7 +138,7 @@ td {
               <td colspan="2">#!SUM-WITH-VAT</td>
             </tr>
           </div>
-        </tfoot>
+        </tbody>
     </table>
 
     <div style="page-break-inside:avoid;">

--- a/src/html/invoice.html
+++ b/src/html/invoice.html
@@ -1,6 +1,6 @@
 <style>
 @media print {
-  @page { margin: 0mm 0mm 0mm 0mm;
+  @page { margin: 2cm 0cm 2cm 0cm;
     size:210mm 297mm;
   }
 }
@@ -46,7 +46,7 @@ td {
 
 </style>
 
-<div style="padding: 2cm;">
+<div style="padding:0cm 2cm 2cm 2cm;">
    
     <div class="container">
         <div style="width: 50%; float: left;">

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.19.0"
   fake_async:
     dependency: transitive
     description:
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.7"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.8"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   screen_retriever:
     dependency: transitive
     description:
@@ -119,7 +143,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -132,26 +156,26 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -164,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -176,14 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.3.0"
   window_manager:
     dependency: "direct dev"
     description:
@@ -193,5 +217,5 @@ packages:
     source: hosted
     version: "0.3.4"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Observation
- the invoice template is not robust against multi-line values in the sender info (i.e. the lines for the description and the values get mismatched)
- is is difficult to change the template
- in case of a page break the top and bottom margins are too small
- if the invoice contains the same item more than once, the numbering in the xml is wrong, i.e. always the index of the first occurance in articles list

Major changes
- implemented the sender info as html table to ensure that key and value always are in the same row; 'reuse' #!SEN-INFO-DESCRIPTION for this
- adapted the creation of the table rows in generate-html.py
- count the index for creating the line numbers for the xml

Annotations
- I'm not the great html writer and there are certainly more elegant ways to do the layout. More css should be used, too . 
- I think the various page break situations work and look quite good
- I hope it's at least a little structural improvement of the templating