### PR TITLE
one directory for all files of one invoice

### DIFF
--- a/src/generator-html.py
+++ b/src/generator-html.py
@@ -157,10 +157,10 @@ def main():
     # Generate invoice number from amount of .pdf files in the invoice folder Format: YYYY-MM-<number>
     # Get all files in the invoice directory
     files = os.listdir(invoice_dir)
-    # Check every file for .pdf
+    # Check every file for Rechnung*
     number = 1
     for file in files:
-        if file.endswith(".pdf"):
+        if file.startswith("Rechnung"):
             number += 1
     invoice_number = datetime.datetime.now().strftime("%Y-%m-") + str(number)
     if args.invoiceNumber != "":
@@ -360,8 +360,9 @@ def main():
         # Copy the default logo
         os.system(f"cp {current_dir}/html/logo.png {cache_dir}/logo.png")
 
-
-    print_path = f"{invoice_dir}/Rechnung-{invoice_number}.pdf"
+    print_path = f"{invoice_dir}/Rechnung-{invoice_number}"
+    os.makedirs(print_path)
+    print_path = f"{print_path}/Rechnung-{invoice_number}.pdf"
     if args.dryRun:
         print("Dry run. Not saving the pdf to the invoice Dir.")
         print_path = f"{cache_dir}/Rechnung.pdf"


### PR DESCRIPTION
Observation:
All files of all invoices of one month are placed in on directory. In consequence this directory get a little bit confusing. I propose a solution that stores all corresponding files in a separate subdirectory of the form `Rechnung_<invoice_number>`.

Why is this getting relevant?
At present there are only 2 files per invoice (the pdf and the xml), but I guess there will be more files in the future:
- another pdf for the combination of pdf and xml e.g. see PR #45
- further files: I'm working on a feature to get cryptographic timestamps for the generated pdf and xml files, to my current understanding this results in further 2 files per timestamped file, a TimeStampRequest and a TimeStampResponse file that one wants to keep in the archive, to be able to verify later that the contents of the original file did not change after the timestamp was created (see also specification RFC 3161 TSA)
- maybe more 'metafiles' will be created later

Solution in this PR
- for every invoice the directory `Rechnung_<invoice_number>` is created in the `invoice_dir` and all created files are moved there from the cache directory at the end
- the automatic generation of the <invoice_number> is adapted, the number of entries in `invoce_dir` that start with `Rechnung_` is used for the counter